### PR TITLE
Add pip dependencies file for `url-check`

### DIFF
--- a/url-check/README.md
+++ b/url-check/README.md
@@ -15,7 +15,11 @@ Installation and configuration
 
 This program is written in Python 3.  It offers a command-line interface.  It should run in any Python environment, although it has only been tested under Mac OS X 10.10 and CentOS Linux.
 
-This program depends on numerous Python modules; most should be normally found in a typical Python installation, but some may need to be installed specially from (e.g.) [PyPi](https://pypi.python.org) using whatever Python package installer you use for your environment.
+You can get dependencies from [PyPi](https://pypi.python.org).  Set up Python 3, `pip`, and ideally `virtualenv`.  Then install the dependencies listed in `requirements.txt` by:
+
+```python
+pip install -r requirements.txt
+```
 
 
 Usage

--- a/url-check/requirements.txt
+++ b/url-check/requirements.txt
@@ -1,0 +1,3 @@
+colorama==0.3.7
+plac==0.9.6
+requests==2.13.0


### PR DESCRIPTION
This provides a simple way for people to install the dependencies
required by this script.