### PR TITLE
Avoid use of problematic module 'colorama'

### DIFF
--- a/url-check/README.md
+++ b/url-check/README.md
@@ -7,7 +7,7 @@ check-ia
 
 *Repository*: [https://github.com/edgi-govdata-archiving/harvesting-tools/tree/master/url-check](https://github.com/edgi-govdata-archiving/harvesting-tools/tree/master/url-check)
 
-*Version*:      1.0
+*Version*:      1.1
 
 ----
 

--- a/url-check/README.md
+++ b/url-check/README.md
@@ -1,4 +1,5 @@
-#check-ia
+check-ia
+========
 
 `check-ia` check if given URLs have been archived in the [Internet Archive](https://archive.org).  It uses the Wayback Machine's [network API](https://archive.org/help/wayback_api.php) to perform the checks.
 

--- a/url-check/check-ia
+++ b/url-check/check-ia
@@ -247,3 +247,11 @@ def cli_interface():
     plac.call(main)
 
 cli_interface()
+
+
+# For Emacs users
+# ......................................................................
+# Local Variables:
+# mode: python
+# python-indent-offset: 4
+# End:

--- a/url-check/check-ia
+++ b/url-check/check-ia
@@ -26,7 +26,6 @@ __author__  = 'Michael Hucka <mhucka@caltech.edu>'
 __email__   = 'mhucka@caltech.edu'
 __license__ = 'Public domain'
 
-import colorama
 import json
 import os
 import plac
@@ -35,6 +34,10 @@ import requests
 import sys
 from urllib.request import urlopen
 from urllib.parse import urlparse
+try:
+    from termcolor import colored
+except:
+    pass
 
 
 # Command line interface
@@ -48,8 +51,6 @@ def main(file=None, okay=None, miss=None, quiet=False, *args):
         raise ValueError('No input file and no URLs given -- nothing to do')
     elif file and not os.path.exists(file):
         raise ValueError('File "{}" not found'.format(file))
-    if not quiet:
-        colorama.init(autoreset=True)
     # Let's do this thing.
     run(file, args, okay, miss, quiet)
 
@@ -119,7 +120,6 @@ def run(input_filename, urls, found_filename, notfound_filename, quiet=False):
         info('{} URLs not found'.format(notfound_count))
     if not quiet:
         info('Done.')
-        print(colorama.Style.RESET_ALL)
 
 
 # Utilities
@@ -224,20 +224,27 @@ def log(dest_file, *args):
         dest_file.write(','.join(args) + '\n')
 
 
+def msg(text, color=None):
+    if color and 'termcolor' in sys.modules:
+        print(colored(text, color), flush=True)
+    else:
+        print(text, flush=True)
+
+
 def bad(text):
-    print(colorama.Fore.RED + text, flush=True)
+    msg(text, 'red')
 
 
 def good(text):
-    print(colorama.Fore.GREEN + text, flush=True)
+    msg(text, 'green')
 
 
 def warning(text):
-    print(colorama.Fore.YELLOW + text, flush=True)
+    msg(text, 'yellow')
 
 
 def info(text):
-    print(text, flush=True)
+    msg(text)
 
 
 # Entry point

--- a/url-check/check-ia
+++ b/url-check/check-ia
@@ -43,7 +43,7 @@ except:
 # Command line interface
 # ......................................................................
 
-def main(file=None, okay=None, miss=None, quiet=False, *args):
+def main(file=None, okay=None, miss=None, quiet=False, nocolor=False, *args):
     # Check for valid arguments.
     if file and args:
         raise ValueError("Can't supply both input file and URLs on command line")
@@ -51,26 +51,32 @@ def main(file=None, okay=None, miss=None, quiet=False, *args):
         raise ValueError('No input file and no URLs given -- nothing to do')
     elif file and not os.path.exists(file):
         raise ValueError('File "{}" not found'.format(file))
+    # Our default is to color output for easier reading, which means the
+    # command line flag makes more sense as a negated value (i.e., "nocolor").
+    # Dealing with a negated variable is confusing, so turn it around here.
+    colorize = 'termcolor' in sys.modules and not nocolor
     # Let's do this thing.
-    run(file, args, okay, miss, quiet)
+    run(file, args, okay, miss, quiet, colorize)
 
 # Plac annotations for main function arguments.
 # Argument annotations are: (help, kind, abbrev, type, choices, metavar).
 # Plac automatically adds a -h argument for help, so no need to do it here.
 #
 main.__annotations__ = dict(
-    file  = ('input file to read for URLs to check',      'option', 'f'),
-    okay  = ('output file to write URLs found in IA',     'option', 'o'),
-    miss  = ('output file to write URLs missing from IA', 'option', 'm'),
-    quiet = ('quiet -- do not echo every check',          'flag',   'q'),
-    args  = '(optional) URLs on the command line',
+    file    = ('input file to read for URLs to check',      'option', 'f'),
+    okay    = ('output file to write URLs found in IA',     'option', 'o'),
+    miss    = ('output file to write URLs missing from IA', 'option', 'm'),
+    quiet   = ('quiet -- do not echo every check',          'flag',   'q'),
+    nocolor = ('do not color-code the output',              'flag',   'x'),
+    args    = '(optional) URLs on the command line',
 )
 
 
 # Main functions
 # ......................................................................
 
-def run(input_filename, urls, found_filename, notfound_filename, quiet=False):
+def run(input_filename, urls, found_filename, notfound_filename,
+        quiet=False, colorize=True):
     found_file     = None
     found_count    = 0
     notfound_file  = None
@@ -87,13 +93,13 @@ def run(input_filename, urls, found_filename, notfound_filename, quiet=False):
                 url = line.strip()
                 if '/' not in url:             # Skip non-URLs
                     continue
-                if check(url, idx, found_file, notfound_file, quiet):
+                if check(url, idx, found_file, notfound_file, quiet, colorize):
                     found_count += 1
                 else:
                     notfound_count += 1
     else:
         for idx, url in enumerate(urls):
-            if check(url, idx, found_file, notfound_file, quiet):
+            if check(url, idx, found_file, notfound_file, quiet, colorize):
                 found_count += 1
             else:
                 notfound_count += 1
@@ -104,28 +110,28 @@ def run(input_filename, urls, found_filename, notfound_filename, quiet=False):
         found_file.close()
         if not quiet:
             if found_count:
-                info('{} URLs found, written to file "{}"'.format(found_count, found_filename))
+                msg('{} URLs found, written to file "{}"'.format(found_count, found_filename))
             else:
-                info('No URLs found.')
+                msg('No URLs found.')
     elif found_count > 0 and not quiet:
-        info('{} URLs found'.format(found_count))
+        msg('{} URLs found'.format(found_count))
     if notfound_filename:
         notfound_file.close()
         if not quiet:
             if notfound_count:
-                info('{} URLS not found, written to file "{}"'.format(notfound_count, notfound_filename))
+                msg('{} URLS not found, written to file "{}"'.format(notfound_count, notfound_filename))
             else:
-                info('All URLs found')
+                msg('All URLs found')
     elif notfound_count > 0 and not quiet:
-        info('{} URLs not found'.format(notfound_count))
+        msg('{} URLs not found'.format(notfound_count))
     if not quiet:
-        info('Done.')
+        msg('Done.')
 
 
 # Utilities
 # ......................................................................
 
-def check(given_url, idx, found_file, notfound_file, quiet=False):
+def check(given_url, idx, found_file, notfound_file, quiet=False, colorize=True):
     try:
         (found, ts, ia_url, status) = url_in_ia(given_url)
         if not found:
@@ -134,24 +140,29 @@ def check(given_url, idx, found_file, notfound_file, quiet=False):
             final_url = get_final_url(given_url)
             (found, ts, ia_url, status) = url_in_ia(final_url)
         if not found:
-            warning('[{}] {} -- not found in IA'.format(idx, given_url))
+            msg('[{}] {} -- not found in IA'
+                .format(idx, given_url), 'warning', colorize)
             log(notfound_file, given_url)
             return False
         elif not ts:
-            warning('[{}] {} -- found, but no data available'.format(idx, given_url))
+            msg('[{}] {} -- found, but no data available'
+                .format(idx, given_url), 'warning', colorize)
             log(found_file, given_url, '00000000000000')
             return True
         elif int(status) > 300:
-            warning('[{}] {} -- found, but IA record has status {}'.format(idx, given_url, status))
+            msg('[{}] {} -- found, but IA record has status {}'
+                .format(idx, given_url, status), 'warning', colorize)
             log(notfound_file, given_url)
             return False
         else:
-            good('[{}] {} -- archived {}'.format(idx, given_url, ts))
+            msg('[{}] {} -- archived {}'
+                .format(idx, given_url, ts), 'success', colorize)
             log(found_file, given_url, ts)
             return True
     except Exception as e:
-        bad('Unable to check {}'.format(given_url))
-        bad(str(e))
+        msg('Unable to check {}'
+            .format(given_url), 'error', colorize)
+        msg(str(e), 'error', colorize)
         return False
 
 
@@ -215,8 +226,7 @@ def get_final_url(url):
         # and hope for the best.
         return url
     except Exception as e:
-        bad('Encountered problem dereferencing {}'.format(url))
-        bad(str(e))
+        raise Exception('Encountered problem dereferencing {}'.format(url))
 
 
 def log(dest_file, *args):
@@ -224,27 +234,24 @@ def log(dest_file, *args):
         dest_file.write(','.join(args) + '\n')
 
 
-def msg(text, color=None):
-    if color and 'termcolor' in sys.modules:
+def msg(text, flag=None, colorize=True):
+    color = None
+    prefix = None
+    if flag is 'error':
+        prefix = 'ERROR'
+        color = 'red'
+    elif flag is 'warning':
+        prefix = 'WARNING'
+        color = 'yellow'
+    elif flag is 'success':
+        color = 'green'
+    if colorize and color:
         print(colored(text, color), flush=True)
-    else:
-        print(text, flush=True)
-
-
-def bad(text):
-    msg(text, 'red')
-
-
-def good(text):
-    msg(text, 'green')
-
-
-def warning(text):
-    msg(text, 'yellow')
-
-
-def info(text):
-    msg(text)
+    elif not colorize:
+        if prefix:
+            print(prefix + ': ' + text, flush=True)
+        else:
+            print(text, flush=True)
 
 
 # Entry point

--- a/url-check/check-ia
+++ b/url-check/check-ia
@@ -21,7 +21,7 @@ Wayback Machine API description: https://archive.org/help/wayback_api.php
 
 '''
 
-__version__ = '1.0'
+__version__ = '1.1'
 __author__  = 'Michael Hucka <mhucka@caltech.edu>'
 __email__   = 'mhucka@caltech.edu'
 __license__ = 'Public domain'

--- a/url-check/requirements.txt
+++ b/url-check/requirements.txt
@@ -1,3 +1,3 @@
-colorama==0.3.7
+termcolor==1.1.0
 plac==0.9.6
 requests==2.13.0


### PR DESCRIPTION
Following problems reported by Justin S. in the Archivers' Slack, I rewrote check-ia to (1) use a different module than `colorama` for colorizing the output, (2) wrap loading the `termcolor` module with a failsafe so that it hopefully won't barf even if it can't load it, and (3) add a new flag (`-x`) to the command line to turn off colorizing the output, in case people want to avoid colorizing the output even if the `termcolor` module is loadable.